### PR TITLE
add: stack support, update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.stack-work
+dist

--- a/hasql-backend.cabal
+++ b/hasql-backend.cabal
@@ -1,7 +1,7 @@
 name:
   hasql-backend
 version:
-  0.4.2
+  0.4.2.1
 synopsis:
   API for backends of "hasql"
 description:
@@ -11,9 +11,9 @@ description:
 category:
   Database
 homepage:
-  https://github.com/nikita-volkov/hasql-backend 
+  https://github.com/nikita-volkov/hasql-backend
 bug-reports:
-  https://github.com/nikita-volkov/hasql-backend/issues 
+  https://github.com/nikita-volkov/hasql-backend/issues
 author:
   Nikita Volkov <nikita.y.volkov@mail.ru>
 maintainer:
@@ -46,16 +46,16 @@ library
     Hasql.Backend
   build-depends:
     -- data:
-    bytestring < 0.11,
-    text < 2,
-    vector < 0.12,
+    bytestring,
+    text,
+    vector,
     -- control:
-    either >= 4.3 && < 5,
-    free >= 4.6 && < 5,
-    list-t < 0.5,
-    transformers >= 0.3 && < 0.5,
+    either,
+    free >= 4.6,
+    list-t,
+    transformers >= 0.3,
     -- general:
-    base-prelude < 0.2
+    base-prelude
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators, UnboxedTuples
   default-language:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+# resolver: lts-2.22  # GHC-7.8
+resolver: lts-3.5


### PR DESCRIPTION
- Removes upper bounds on dependencies
- Adds stack support, defaulting to GHC-7.10
- Tested with: GHC-7.8.4, GHC-7.10.2
- Tested against updated: hasql, hasql-postgresql
- .gitignore for dist, .stack-work

Here's everything working together:

```
allele@parametric:~/dev/hasql:$ stack clean
allele@parametric:~/dev/hasql:$ ls
hasql  hasql-backend  hasql-postgres  stack.yaml
allele@parametric:~/dev/hasql:$ more stack.yaml 
```

``` yaml
flags: {}
packages:
- hasql/
- hasql-backend/
- hasql-postgres/
extra-deps:
  - criterion-plus-0.1.3
  - HDBC-2.4.0.1
  - HDBC-postgresql-2.3.2.3
resolver: lts-3.5
```

```
allele@parametric:~/dev/hasql:$ stack build
hasql-0.7.4.1-20792b88031018a947c17120d8d34883: unregistering (missing dependencies: hasql-backend)
hasql-backend-0.4.2.1-9959897ad3289b5d63d117ec27d34e52: unregistering (local file changes)
hasql-postgres-0.10.5.1-18a2f341b426f90a2f04dca5868cd235: unregistering (missing dependencies: hasql-backend)
hasql-backend-0.4.2.1: configure
hasql-backend-0.4.2.1: build
hasql-backend-0.4.2.1: install
hasql-0.7.4.1: configure
hasql-0.7.4.1: build
hasql-postgres-0.10.5.1: configure
hasql-postgres-0.10.5.1: build
hasql-0.7.4.1: install
hasql-postgres-0.10.5.1: install
Completed all 3 actions.
```
